### PR TITLE
Use of active twigcs package for phaudit images

### DIFF
--- a/phaudit/7.0/Dockerfile
+++ b/phaudit/7.0/Dockerfile
@@ -44,7 +44,7 @@ RUN set -xe; \
         phpstan/phpstan-shim \
         phpstan/phpstan-strict-rules; \
     composer bin symfony-friendly require --optimize-autoloader \
-        allocine/twigcs \
+        friendsoftwig/twigcs \
         friendsofphp/php-cs-fixer \
         heahdude/yaml-linter \
         pdepend/pdepend \

--- a/phaudit/7.1/Dockerfile
+++ b/phaudit/7.1/Dockerfile
@@ -44,7 +44,7 @@ RUN set -xe; \
         phpstan/phpstan-shim \
         phpstan/phpstan-strict-rules; \
     composer bin symfony-friendly require --optimize-autoloader \
-        allocine/twigcs \
+        friendsoftwig/twigcs \
         friendsofphp/php-cs-fixer \
         heahdude/yaml-linter \
         pdepend/pdepend \

--- a/phaudit/7.2/Dockerfile
+++ b/phaudit/7.2/Dockerfile
@@ -44,7 +44,7 @@ RUN set -xe; \
         phpstan/phpstan-shim \
         phpstan/phpstan-strict-rules; \
     composer bin symfony-friendly require --optimize-autoloader \
-        allocine/twigcs \
+        friendsoftwig/twigcs \
         friendsofphp/php-cs-fixer \
         heahdude/yaml-linter \
         pdepend/pdepend \

--- a/phaudit/7.3/Dockerfile
+++ b/phaudit/7.3/Dockerfile
@@ -44,7 +44,7 @@ RUN set -xe; \
         phpstan/phpstan-shim \
         phpstan/phpstan-strict-rules; \
     composer bin symfony-friendly require --optimize-autoloader \
-        allocine/twigcs \
+        friendsoftwig/twigcs \
         friendsofphp/php-cs-fixer \
         heahdude/yaml-linter \
         pdepend/pdepend \


### PR DESCRIPTION
allocine/twigcs package is abandoned.  The author suggests using the friendsoftwig/twigcs package instead.